### PR TITLE
fix pytorch RCE vulnerability

### DIFF
--- a/DeepSeek OCR/container/Dockerfile
+++ b/DeepSeek OCR/container/Dockerfile
@@ -1,6 +1,7 @@
 # DeepSeek OCR SageMaker BYOC with Transformers
 # Using NVIDIA NGC registry (no rate limits like Docker Hub)
-FROM nvcr.io/nvidia/cuda:12.1.0-devel-ubuntu22.04
+# CUDA 12.4 required for PyTorch 2.6.0 (fixes CRITICAL RCE CVE)
+FROM nvcr.io/nvidia/cuda:12.4.1-devel-ubuntu22.04
 
 # System packages
 RUN apt-get update && \
@@ -22,11 +23,11 @@ RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1
 # Upgrade pip
 RUN python3 -m pip install --no-cache-dir --upgrade pip setuptools wheel
 
-# Install PyTorch with CUDA 12.1
+# Install PyTorch with CUDA 12.4 (2.6.0 fixes CRITICAL RCE CVE in torch.load)
 RUN pip install --no-cache-dir \
-    torch==2.5.1 \
-    torchvision==0.20.1 \
-    --index-url https://download.pytorch.org/whl/cu121
+    torch==2.6.0 \
+    torchvision==0.21.0 \
+    --index-url https://download.pytorch.org/whl/cu124
 
 # Install ninja and psutil (required for flash-attn compilation)
 RUN pip install --no-cache-dir ninja psutil packaging

--- a/DeepSeek OCR/container/requirements.txt
+++ b/DeepSeek OCR/container/requirements.txt
@@ -10,8 +10,8 @@
 # - Pin exact versions for reproducibility
 
 ## Deep Learning Framework
-torch==2.5.1              # PyTorch with CUDA 12.1 support
-torchvision==0.20.1       # Vision utilities (installed with torch)
+torch==2.6.0              # PyTorch with CUDA 12.4 support (2.6.0 fixes CRITICAL RCE CVE)
+torchvision==0.21.0       # Vision utilities (installed with torch)
 
 ## Model Backend
 transformers==4.46.3      # HuggingFace Transformers (official DeepSeek-OCR backend)


### PR DESCRIPTION
Upgrade PyTorch to fix remote code execution vulnerability where
  torch.load with weights_only=True still allows arbitrary code execution.

  Changes:
  - Upgrade CUDA 12.1.0 → 12.4.1 (required for PyTorch 2.6.0)
  - Upgrade torch 2.5.1 → 2.6.0 (fixes RCE CVE per Dependabot alert #15)
  - Upgrade torchvision 0.20.1 → 0.21.0

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
