### PR TITLE
Update README add self-hosting guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,13 @@ Open a PR if you would like to contribute! :twisted_rightwards_arrows:
 
 ## What's New
 
-- [DeepSeek-R1 model now available in Amazon Bedrock Marketplace and Amazon SageMaker JumpStart](https://aws.amazon.com/blogs/machine-learning/deepseek-r1-model-now-available-in-amazon-bedrock-marketplace-and-amazon-sagemaker-jumpstart/): This blog post discusses how to get started with DeepSeek-R1 on Amazon Bedrock Marketplace and SageMaker JumpStart. 
+- [DeepSeek-R1 model now available in Amazon Bedrock Marketplace and Amazon SageMaker JumpStart](https://aws.amazon.com/blogshttps://github.com/aws-samples/deepseek-on-AWS/blob/main/README.md/machine-learning/deepseek-r1-model-now-available-in-amazon-bedrock-marketplace-and-amazon-sagemaker-jumpstart/): This blog post discusses how to get started with DeepSeek-R1 on Amazon Bedrock Marketplace and SageMaker JumpStart. 
 
 - [Deploy DeepSeek-R1 distilled Llama models with Amazon Bedrock Custom Model Import](https://aws.amazon.com/blogs/machine-learning/deploy-deepseek-r1-distilled-llama-models-with-amazon-bedrock-custom-model-import/): This blog post discusses how to deploy R1 Distilled Llama models on Amazon Bedrock using Custom Model Import, which enables the import and use of your customized models alongside existing FMs through a single serverless, unified API. 
 
-- [Protect your DeepSeek model deployments with Amazon Bedrock Guardrails](https://aws.amazon.com/blogs/machine-learning/protect-your-deepseek-model-deployments-with-amazon-bedrock-guardrails/): This blog post provides a comprehensive guide to implementing robust safety protections for DeepSeek-R1 and other open weight models using Amazon Bedrock Guardrails. We’ll explore: 
+- [Protect your DeepSeek model deployments with Amazon Bedrock Guardrails](https://aws.amazon.com/blogs/machine-learning/protect-your-deepseek-model-deployments-with-amazon-bedrock-guardrails/): This blog post provides a comprehensive guide to implementing robust safety protections for DeepSeek-R1 and other open weight models using Amazon Bedrock Guardrails. We’ll explore:
+
+Here is a way to self host Deep Seek with AWS with Infrastructure as Code: https://github.com/aws-samples/sample-deepseek-ocr-selfhost
 
 ## Notebooks 
 


### PR DESCRIPTION
This pull request makes a small update to the `README.md` file, correcting the link for the DeepSeek-R1 model blog post and adding a new resource for self-hosting DeepSeek with AWS using Infrastructure as Code.